### PR TITLE
Adjusted links to use the .org domain and HTTPS.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta content="X5tHeKjV-jMLyp4VMoUhW9PAYaOjtPslV250" name="csrf-token">
 
   <title>Terms of Service | freeCodeCamp</title>
-  <link href="http://freecodecamp.com" rel="canonical">
+  <link href="https://www.freecodecamp.org" rel="canonical">
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
@@ -20,7 +20,7 @@
   <meta content="freeCodeCamp" property="og:site_name">
   <meta content="on" name="twitter:widgets:csp">
   <meta content="d0bc047a482c03c24f1168004c2a216a" name="p:domain_verify">
-  <meta content="http://www.freecodecamp.com" property="og:url">
+  <meta content="https://www.freecodecamp.org" property="og:url">
   <meta content=
   "Learn to code and build projects for nonprofits. Build your full stack web development portfolio today."
   property="og:description">
@@ -37,7 +37,7 @@
   "Learn to code and build projects for nonprofits. Build your full stack web development portfolio today."
   name="description">
   <meta content="@freecodecamp" name="twitter:creator">
-  <meta content="http://www.freecodecamp.com" name="twitter:url">
+  <meta content="https://www.freecodecamp.org" name="twitter:url">
   <meta content="@freecodecamp" name="twitter:site">
   <meta content="summary_large_image" name="twitter:card">
   <meta content=
@@ -162,7 +162,7 @@
     <div class="return-to-free-code-camp">
       <ul class="nav navbar-nav navbar-right">
         <li class="hidden-xs return-to-free-code-camp wrappable">
-          <a href="https://www.freecodecamp.com">Return to freeCodeCamp.com</a>
+          <a href="https://www.freecodecamp.org">Return to freeCodeCamp.org</a>
         </li>
       </ul>
     </div>
@@ -189,7 +189,7 @@
       <h3><a id="The_gist_2"></a>The gist:</h3>
 
 
-      <p>We (the <a href="http://freeCodeCamp.com/about/">folks that run
+      <p>We (the <a href="http://www.freeCodeCamp.org/about/">folks that run
       freeCodeCamp's open source community</a>) would <strong>love</strong> for
       you to use it. Our community is free, and our service is designed to give
       you as much control and ownership over the code you write as possible,
@@ -198,20 +198,20 @@
       items (like spam, viruses, or serious threats of violence) appear on your
       website. If you find anything on freeCodeCamp that you believe violates
       these Terms of Service, please email us at
-      <a href="mailto:team@freecodecamp.com">team@freecodecamp.com</a></p>
+      <a href="mailto:team@freecodecamp.org">team@freecodecamp.org</a></p>
 
 
       <h3><a id="Terms_of_Service_10"></a>Terms of Service:</h3>
 
 
       <p>The following terms and conditions govern all use of the <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a> website and all content,
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a> website and all content,
       services, and products available at or through the website - taken
       together, our Services. Our Services are offered subject to your
       acceptance without modification of all of the terms and conditions
       contained herein and all other operating rules, policies (including,
       without limitation, <a href=
-      "http://freecodecamp.com/privacy/">freeCodeCamp's Privacy Policy</a>) and
+      "https://www.freecodecamp.org/privacy/">freeCodeCamp's Privacy Policy</a>) and
       procedures that may be published from time to time by freeCodeCamp
       (collectively, the “Agreement”). You agree that we may automatically
       upgrade our Services, and these terms will apply to any upgrades. Your
@@ -228,21 +228,21 @@
       registers as a user or provides their personal information to our
       Services represents that they are 13 years of age or older. Use of some
       aspects of our Services may require a <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a> account. You agree to
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a> account. You agree to
       provide us with complete and accurate information when you register for
       an account. You will be solely responsible and liable for any activity
       that occurs under your username. You are responsible for keeping your
       password secure.</p>
 
 
-      <h4>1. <a href="http://freeCodeCamp.com">freeCodeCamp.com</a>.</h4>
+      <h4>1. <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a>.</h4>
 
 
       <ul>
         <li>
-          <strong>Your <a href="http://freeCodeCamp.com">freeCodeCamp.com</a>
+          <strong>Your <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a>
           Account and Website.</strong> If you create a website on <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a>, you are responsible
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a>, you are responsible
           for maintaining the security of your account and website, and you are
           fully responsible for all activities that occur under the account and
           any other actions taken in connection with the website. You must
@@ -257,17 +257,17 @@
         <li>
           <strong>Responsibility of Contributors.</strong> If you operate a
           website, comment on a website, post material to <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a>, post links on
-          <a href="http://freeCodeCamp.com">freeCodeCamp.com</a>, or otherwise
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a>, post links on
+          <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a>, or otherwise
           make (or allow any third party to make) material available (any such
           material, “Content”), you are entirely responsible for the content
           of, and any harm resulting from, that Content or your conduct. That
           is the case regardless of what form the Content takes, which
           includes, but is not limited to text, photo, video, audio, or code.
-          By using <a href="http://freeCodeCamp.com">freeCodeCamp.com</a>, you
+          By using <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a>, you
           represent and warrant that your Content and conduct do not violate
           these terms or the <a href=
-          "http://freeCodeCamp.com/code-of-conduct/">Code of Conduct</a>. By
+          "https://www.freeCodeCamp.org/code-of-conduct/">Code of Conduct</a>. By
           submitting Content to freeCodeCamp for inclusion on your website, you
           grant freeCodeCamp a world-wide, royalty-free, and non-exclusive
           license to reproduce, modify, adapt and publish the Content solely
@@ -277,14 +277,14 @@
           the freeCodeCamp Firehose, for example) so that these third parties
           can analyze and distribute (but not publicly display) your content
           through their services. You also give other <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a> users permission to
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a> users permission to
           share your Content on other <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a> websites and add their
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a> websites and add their
           own Content to it (aka to reblog your Content), so long as they use
           only a portion of your post and they give you credit as the original
           author by linking back to your website. If you delete Content,
           freeCodeCamp will use reasonable efforts to remove it from <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a>, but you acknowledge
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a>, but you acknowledge
           that caching or references to the Content may not be made immediately
           unavailable. Without limiting any of those representations or
           warranties, freeCodeCamp has the right (though not the obligation)
@@ -292,7 +292,7 @@
           content that, in freeCodeCamp’s reasonable opinion, violates any
           freeCodeCamp policy or is in any way harmful or objectionable, or
           (ii) terminate or deny access to and use of <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a> to any individual or
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a> to any individual or
           entity for any reason. freeCodeCamp will have no obligation to
           provide a refund of any amounts previously paid.
         </li>
@@ -301,7 +301,7 @@
         <li>
           <strong>Attribution.</strong> freeCodeCamp reserves the right to
           display attribution links such as ‘Website at <a href=
-          "http://freeCodeCamp.com">freeCodeCamp.com</a>,’ theme author, and
+          "https://www.freeCodeCamp.org">freeCodeCamp.org</a>,’ theme author, and
           font attribution in your website footer or toolbar.
         </li>
       </ul>
@@ -337,17 +337,17 @@
 
       <p>We have not reviewed, and cannot review, all of the material,
       including computer software, made available through the websites and
-      webpages to which <a href="http://freeCodeCamp.com">freeCodeCamp.com</a>
+      webpages to which <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a>
       links, and that link to <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a>. freeCodeCamp does not
-      have any control over those non-freeCodeCamp.com websites, and is not
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a>. freeCodeCamp does not
+      have any control over those non-freeCodeCamp.org websites, and is not
       responsible for their contents or their use. By linking to a
-      non-freeCodeCamp.com website, freeCodeCamp does not represent or imply
+      non-freeCodeCamp.org website, freeCodeCamp does not represent or imply
       that it endorses such website. You are responsible for taking precautions
       as necessary to protect yourself and your computer systems from viruses,
       worms, Trojan horses, and other harmful or destructive content.
       freeCodeCamp disclaims any responsibility for any harm resulting from
-      your use of non-freeCodeCamp.com websites and webpages.</p>
+      your use of non-freeCodeCamp.org websites and webpages.</p>
 
 
       <h4><a id="6_Copyright_Infringement_and_DMCA_Policy_57"></a>6. Copyright
@@ -357,9 +357,9 @@
       <p>As freeCodeCamp asks others to respect its intellectual property
       rights, it respects the intellectual property rights of others. If you
       believe that material located on or linked to by <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a> violates your copyright,
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a> violates your copyright,
       you are encouraged to notify freeCodeCamp in accordance with <a href=
-      "http://freeCodeCamp.com/dmca-notice/">freeCodeCamp’s Digital Millennium
+      "https://www.freeCodeCamp.org/dmca-notice/">freeCodeCamp’s Digital Millennium
       Copyright Act (“DMCA”) Policy</a>. freeCodeCamp will respond to all such
       notices, including as required or appropriate by removing the infringing
       material or disabling all links to the infringing material. freeCodeCamp
@@ -376,10 +376,10 @@
       freeCodeCamp or third party intellectual property, and all right, title,
       and interest in and to such property will remain (as between the parties)
       solely with freeCodeCamp. freeCodeCamp, <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a>, the <a href=
-      "http://freeCodeCamp.com">freeCodeCamp.com</a> logo, and all other
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a>, the <a href=
+      "https://www.freeCodeCamp.org">freeCodeCamp.org</a> logo, and all other
       trademarks, service marks, graphics and logos used in connection with
-      <a href="http://freeCodeCamp.com">freeCodeCamp.com</a> or our Services,
+      <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a> or our Services,
       are trademarks or registered trademarks of freeCodeCamp or freeCodeCamp’s
       licensors. Other trademarks, service marks, graphics and logos used in
       connection with our Services may be the trademarks of other third
@@ -410,7 +410,7 @@
       <p>freeCodeCamp may terminate your access to all or any part of our
       Services at any time, with or without cause, with or without notice,
       effective immediately. If you wish to terminate this Agreement or your
-      <a href="http://freeCodeCamp.com">freeCodeCamp.com</a> account (if you
+      <a href="https://www.freeCodeCamp.org">freeCodeCamp.org</a> account (if you
       have one), you may simply discontinue using our Services. All provisions
       of this Agreement which by their nature should survive termination shall
       survive termination, including, without limitation, ownership provisions,
@@ -539,7 +539,7 @@
 
       <hr>
 
-      <p>If you have questions about these terms of service, email us at <a href="mailto:team@freecodecamp.com">team@freecodecamp.com</a>.</p>
+      <p>If you have questions about these terms of service, email us at <a href="mailto:team@freecodecamp.org">team@freecodecamp.org</a>.</p>
     </div>
   </div>
   <!-- scripts should be moved here-->


### PR DESCRIPTION
This updates the links to use the freecodecamp.org domain name as opposed to the old freecodecamp.com domain name, links also use HTTPS now.